### PR TITLE
proxy: add support for whitelist_on_all_connections_blacklisted configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ production:
     # the following are default values
     blacklist_duration: 5
     master_ttl: 5
+    whitelist_on_all_connections_blacklisted: true
     master_strategy: round_robin
     sticky: true
 
@@ -177,6 +178,7 @@ The makara subconfig sets up the proxy with a few of its own options, then provi
 * disable_blacklist - do not blacklist node at any error, useful in case of one master
 * sticky - if a node should be stuck to once it's used during a specific context
 * master_ttl - how long the master context is persisted. generally, this needs to be longer than any replication lag
+* whitelist_on_all_connections_blacklisted - should connections be whitelisted/enabled after they are all blacklisted
 * master_strategy - use a different strategy for picking the "current" master node: `failover` will try to keep the same one until it is blacklisted. The default is `round_robin` which will cycle through available ones.
 * slave_strategy - use a different strategy for picking the "current" slave node: `failover` will try to keep the same one until it is blacklisted. The default is `round_robin` which will cycle through available ones.
 * connection_error_matchers - array of custom error matchers you want to be handled gracefully by Makara (as in, errors matching these regexes will result in blacklisting the connection as opposed to raising directly).

--- a/lib/makara/config_parser.rb
+++ b/lib/makara/config_parser.rb
@@ -23,7 +23,8 @@ module Makara
     DEFAULTS = {
       master_ttl: 5,
       blacklist_duration: 30,
-      sticky: true
+      sticky: true,
+      whitelist_on_all_connections_blacklisted: true
     }
 
     # ConnectionUrlResolver is borrowed from Rails 4-2 since its location and implementation

--- a/spec/config_parser_spec.rb
+++ b/spec/config_parser_spec.rb
@@ -25,6 +25,7 @@ describe Makara::ConfigParser do
     let(:config_without_url) do
       {
         master_ttl: 5,
+        whitelist_on_all_connections_blacklisted: true,
         blacklist_duration: 30,
         sticky: true,
         adapter: 'mysql2_makara',
@@ -40,6 +41,7 @@ describe Makara::ConfigParser do
     let(:config_with_url) do
       {
         master_ttl: 5,
+        whitelist_on_all_connections_blacklisted: true,
         blacklist_duration: 30,
         sticky: true,
         adapter: 'mysql2_makara',
@@ -115,7 +117,8 @@ describe Makara::ConfigParser do
           top_level: 'value',
           sticky: true,
           blacklist_duration: 30,
-          master_ttl: 5
+          master_ttl: 5,
+          whitelist_on_all_connections_blacklisted: true
         }
       ])
       expect(parser.slave_configs).to eq([
@@ -124,14 +127,16 @@ describe Makara::ConfigParser do
           top_level: 'value',
           sticky: true,
           blacklist_duration: 30,
-          master_ttl: 5
+          master_ttl: 5,
+          whitelist_on_all_connections_blacklisted: true
         },
         {
           name: 'slave2',
           top_level: 'value',
           sticky: true,
           blacklist_duration: 30,
-          master_ttl: 5
+          master_ttl: 5,
+          whitelist_on_all_connections_blacklisted: true
         }
       ])
     end
@@ -148,7 +153,8 @@ describe Makara::ConfigParser do
           top_level: 'value',
           sticky: true,
           blacklist_duration: 456,
-          master_ttl: 5
+          master_ttl: 5,
+          whitelist_on_all_connections_blacklisted: true
         }
       ])
       expect(parser.slave_configs).to eq([
@@ -157,14 +163,16 @@ describe Makara::ConfigParser do
           top_level: 'slave value',
           sticky: true,
           blacklist_duration: 123,
-          master_ttl: 5
+          master_ttl: 5,
+          whitelist_on_all_connections_blacklisted: true
         },
         {
           name: 'slave2',
           top_level: 'value',
           sticky: true,
           blacklist_duration: 123,
-          master_ttl: 5
+          master_ttl: 5,
+          whitelist_on_all_connections_blacklisted: true
         }
       ])
     end


### PR DESCRIPTION
This adds support for a config variable `whitelist_on_all_connections_blacklisted` that defaults to true to preserve legacy behavior. This behavior is problematic as regardless of pool, all connections get whitelisted when handling the condition, which allows traffic to non-existent servers.