### PR TITLE
proxy: add support for whitelist_on_all_connections_blacklisted configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ production:
     # the following are default values
     blacklist_duration: 5
     master_ttl: 5
+    whitelist_on_all_connections_blacklisted: true
     master_strategy: round_robin
     sticky: true
 
@@ -176,6 +177,7 @@ The makara subconfig sets up the proxy with a few of its own options, then provi
 * disable_blacklist - do not blacklist node at any error, useful in case of one master
 * sticky - if a node should be stuck to once it's used during a specific context
 * master_ttl - how long the master context is persisted. generally, this needs to be longer than any replication lag
+* whitelist_on_all_connections_blacklisted - should connections be whitelisted/enabled after they are all blacklisted
 * master_strategy - use a different strategy for picking the "current" master node: `failover` will try to keep the same one until it is blacklisted. The default is `round_robin` which will cycle through available ones.
 * slave_strategy - use a different strategy for picking the "current" slave node: `failover` will try to keep the same one until it is blacklisted. The default is `round_robin` which will cycle through available ones.
 * connection_error_matchers - array of custom error matchers you want to be handled gracefully by Makara (as in, errors matching these regexes will result in blacklisting the connection as opposed to raising directly).

--- a/lib/makara/config_parser.rb
+++ b/lib/makara/config_parser.rb
@@ -24,7 +24,8 @@ module Makara
     DEFAULTS = {
       :master_ttl => 5,
       :blacklist_duration => 30,
-      :sticky => true
+      :sticky => true,
+      :whitelist_on_all_connections_blacklisted => true
     }
 
     # ConnectionUrlResolver is borrowed from Rails 4-2 since its location and implementation

--- a/lib/makara/proxy.rb
+++ b/lib/makara/proxy.rb
@@ -59,14 +59,15 @@ module Makara
     attr_reader :control
 
     def initialize(config)
-      @config         = config.symbolize_keys
-      @config_parser  = Makara::ConfigParser.new(@config)
-      @id             = @config_parser.id
-      @ttl            = @config_parser.makara_config[:master_ttl]
-      @sticky         = @config_parser.makara_config[:sticky]
-      @hijacked       = false
-      @error_handler  ||= ::Makara::ErrorHandler.new
-      @skip_sticking  = false
+      @config                                   = config.symbolize_keys
+      @config_parser                            = Makara::ConfigParser.new(@config)
+      @id                                       = @config_parser.id
+      @ttl                                      = @config_parser.makara_config[:master_ttl]
+      @whitelist_on_all_connections_blacklisted = @config_parser.makara_config[:whitelist_on_all_connections_blacklisted]
+      @sticky                                   = @config_parser.makara_config[:sticky]
+      @hijacked                                 = false
+      @error_handler                            ||= ::Makara::ErrorHandler.new
+      @skip_sticking                            = false
       instantiate_connections
       super(config)
     end
@@ -212,8 +213,10 @@ module Makara
 
     rescue ::Makara::Errors::AllConnectionsBlacklisted, ::Makara::Errors::NoConnectionsAvailable => e
       if pool == @master_pool
-        @master_pool.connections.each(&:_makara_whitelist!)
-        @slave_pool.connections.each(&:_makara_whitelist!)
+        if @whitelist_on_all_connections_blacklisted
+          @master_pool.connections.each(&:_makara_whitelist!)
+          @slave_pool.connections.each(&:_makara_whitelist!)
+        end
         Kernel.raise e
       else
         @master_pool.blacklist_errors << e

--- a/spec/config_parser_spec.rb
+++ b/spec/config_parser_spec.rb
@@ -26,6 +26,7 @@ describe Makara::ConfigParser do
     let(:config_without_url) do
       {
         :master_ttl => 5,
+        :whitelist_on_all_connections_blacklisted => true,
         :blacklist_duration => 30,
         :sticky => true,
         :adapter => 'mysql2_makara',
@@ -41,6 +42,7 @@ describe Makara::ConfigParser do
     let(:config_with_url) do
       {
         :master_ttl => 5,
+        :whitelist_on_all_connections_blacklisted => true,
         :blacklist_duration => 30,
         :sticky => true,
         :adapter => 'mysql2_makara',
@@ -117,7 +119,8 @@ describe Makara::ConfigParser do
           :top_level => 'value',
           :sticky => true,
           :blacklist_duration => 30,
-          :master_ttl => 5
+          :master_ttl => 5,
+          :whitelist_on_all_connections_blacklisted => true
         }
       ])
       expect(parser.slave_configs).to eq([
@@ -126,14 +129,16 @@ describe Makara::ConfigParser do
           :top_level => 'value',
           :sticky => true,
           :blacklist_duration => 30,
-          :master_ttl => 5
+          :master_ttl => 5,
+          :whitelist_on_all_connections_blacklisted => true
         },
         {
           :name => 'slave2',
           :top_level => 'value',
           :sticky => true,
           :blacklist_duration => 30,
-          :master_ttl => 5
+          :master_ttl => 5,
+          :whitelist_on_all_connections_blacklisted => true
         }
       ])
     end
@@ -150,7 +155,8 @@ describe Makara::ConfigParser do
           :top_level => 'value',
           :sticky => true,
           :blacklist_duration => 456,
-          :master_ttl => 5
+          :master_ttl => 5,
+          :whitelist_on_all_connections_blacklisted => true
         }
       ])
       expect(parser.slave_configs).to eq([
@@ -159,14 +165,16 @@ describe Makara::ConfigParser do
           :top_level => 'slave value',
           :sticky => true,
           :blacklist_duration => 123,
-          :master_ttl => 5
+          :master_ttl => 5,
+          :whitelist_on_all_connections_blacklisted => true
         },
         {
           :name => 'slave2',
           :top_level => 'value',
           :sticky => true,
           :blacklist_duration => 123,
-          :master_ttl => 5
+          :master_ttl => 5,
+          :whitelist_on_all_connections_blacklisted => true
         }
       ])
     end

--- a/spec/proxy_spec.rb
+++ b/spec/proxy_spec.rb
@@ -207,5 +207,31 @@ describe Makara::Proxy do
       proxy.slave_pool.connections.each{|con| expect(con._makara_blacklisted?).to eq(false) }
       proxy.master_pool.connections.each{|con| expect(con._makara_blacklisted?).to eq(false) }
     end
+
+    it 'should raise the error and not whitelist all connections if everything is blacklisted and whitelist_on_all_connections_blacklisted is false' do
+      config = config(1, 1).dup
+      config[:makara][:whitelist_on_all_connections_blacklisted] = false
+      proxy = klass.new(config)
+      proxy.ping
+
+      # weird setup to allow for the correct
+      proxy.slave_pool.connections.each(&:_makara_blacklist!)
+      proxy.slave_pool.instance_variable_get('@blacklist_errors') << StandardError.new('some slave connection issue')
+      proxy.master_pool.connections.each(&:_makara_blacklist!)
+      proxy.master_pool.instance_variable_get('@blacklist_errors') << StandardError.new('some master connection issue')
+
+      allow(proxy).to receive(:_appropriate_pool).and_return(proxy.slave_pool, proxy.master_pool)
+
+      begin
+        proxy.send(:appropriate_pool, :execute, ['select * from users']) do |pool|
+          pool.provide{|c| c }
+        end
+      rescue Makara::Errors::AllConnectionsBlacklisted => e
+        expect(e.message).to eq('[Makara/master] All connections are blacklisted -> some master connection issue -> [Makara/slave] All connections are blacklisted -> some slave connection issue')
+      end
+
+      proxy.slave_pool.connections.each{|con| expect(con._makara_blacklisted?).to eq(true) }
+      proxy.master_pool.connections.each{|con| expect(con._makara_blacklisted?).to eq(true) }
+    end
   end
 end


### PR DESCRIPTION
This adds support for a config variable `whitelist_on_all_connections_blacklisted` that defaults to true to preserve legacy behavior. This behavior is problematic as regardless of pool, all connections get whitelisted when handling the condition, which allows traffic to non-existent servers.

This is the same as https://github.com/justworkshr/makara/pull/1 but based off of `v0.5.0` as `v0.5.1` drops support for ActiveRecord < 5.2.